### PR TITLE
Fetch Data from rocket API

### DIFF
--- a/src/Components/redux/Rockets/FetchRockets.js
+++ b/src/Components/redux/Rockets/FetchRockets.js
@@ -1,0 +1,20 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+const url = 'https://api.spacexdata.com/v3/rockets';
+
+const fetchRockets = createAsyncThunk('mission/fetchRockets', async () => {
+  const response = await fetch(url);
+  const data = await response.json();
+
+  // Extracting mission_id, mission_name, and description from the API response
+  const rockets = data.map((rocket) => ({
+    id: rocket.id,
+    rocket_name: rocket.rocket_name,
+    rocket_type: rocket.rocket_type,
+    flickr_images: rocket.flickr_images,
+  }));
+
+  return rockets;
+});
+
+export default fetchRockets;

--- a/src/Components/redux/Rockets/RocketSlices.js
+++ b/src/Components/redux/Rockets/RocketSlices.js
@@ -1,0 +1,31 @@
+import { createSlice } from '@reduxjs/toolkit';
+import fetchRockets from './FetchRockets';
+
+const initialState = {
+  rockets: [],
+  loading: false,
+};
+
+const rocketSlice = createSlice({
+  name: 'mission',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchRockets.pending, (state) => ({
+        ...state,
+        loading: true,
+      }))
+      .addCase(fetchRockets.fulfilled, (state, action) => ({
+        ...state,
+        loading: false,
+        rockets: action.payload,
+      }))
+      .addCase(fetchRockets.rejected, (state) => ({
+        ...state,
+        loading: false,
+      }));
+  },
+});
+
+export default rocketSlice.reducer;

--- a/src/Components/redux/store.js
+++ b/src/Components/redux/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import MissionsReducer from './Missions/MissionsSlices';
+import RocketReducers from './Rockets/RocketSlices';
 
 const store = configureStore({
   reducer: {
     Missions: MissionsReducer,
+    Rockets: RocketReducers,
   },
 });
 

--- a/src/Components/routes/Rockets.jsx
+++ b/src/Components/routes/Rockets.jsx
@@ -1,9 +1,19 @@
-import React from 'react';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import fetchRockets from '../redux/Rockets/FetchRockets';
 
-const Rockets = () => (
-  <div>
-    <h1>Rockets</h1>
-  </div>
-);
+const Rockets = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchRockets());
+  }, [dispatch]);
+
+  return (
+    <div>
+      <h1>Rockets</h1>
+    </div>
+  );
+};
 
 export default Rockets;


### PR DESCRIPTION
This pull request introduces the necessary changes to fetch data from the Rockets endpoint (https://api.spacexdata.com/v3/rockets) when the application starts. Additionally, it dispatches an action to store the selected data in the Redux store, specifically the following properties:

id
name
type
flickr_images
To ensure efficiency and prevent unnecessary re-rendering, the implementation ensures that the data is dispatched to the Redux store only once, avoiding duplicate entries during view changes or navigation.

Please review and merge these changes at your convenience.